### PR TITLE
fix: only get releases if they do not exist

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -21,4 +21,6 @@ pub enum SolcVmError {
     SemverError(#[from] semver::Error),
     #[error(transparent)]
     UrlError(#[from] url::ParseError),
+    #[error(transparent)]
+    SerdeError(#[from] serde_json::Error),
 }

--- a/src/svm/main.rs
+++ b/src/svm/main.rs
@@ -23,7 +23,7 @@ enum SolcVm {
 async fn main() -> anyhow::Result<()> {
     let opt = SolcVm::from_args();
 
-    svm_lib::setup_home()?;
+    svm_lib::setup_home().await?;
 
     match opt {
         SolcVm::List => {


### PR DESCRIPTION
Allows caching the Releases to a releases.json so that 3rd parties do not unnecessarily re-download them every time. We could maybe add some "svm update-releases" command which would force-redownload the file, to update it if it changes.

The motivation is that https://github.com/gakonst/ethers-rs/pull/614 made it so that a releases request is made every time, and that can slows down [Foundry's startup time](https://github.com/gakonst/foundry/blob/master/forge/src/multi_runner.rs#L45)