### PR TITLE
replace structopt with clap3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,13 +72,32 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "1957aa4a5fb388f0a0a73ce7556c5b42025b874e5cdc2c670775e346e97adec0"
 dependencies = [
+ "atty",
  "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "517358c28fcef6607bf6f76108e02afad7e82297d132a6b846dcc1fc3efcd153"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -284,12 +314,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -633,6 +660,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1046,28 +1082,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "structopt"
-version = "0.3.25"
+name = "strsim"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "svm-rs"
@@ -1075,6 +1093,7 @@ version = "0.2.1"
 dependencies = [
  "anyhow",
  "cfg-if",
+ "clap",
  "console 0.14.1",
  "dialoguer",
  "hex",
@@ -1088,7 +1107,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "structopt",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1121,6 +1139,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,12 +1159,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thiserror"
@@ -1291,12 +1315,6 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
@@ -1476,6 +1494,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,17 +30,19 @@ console = { version = "0.14.1", default-features = false }
 dialoguer = { version = "0.8.0", default-features = false }
 home = { version = "0.5.3", default-features = false }
 indicatif = { version = "0.16.2", default-features = false }
-itertools = { version = "0.10.1", default-features = false, features = ["use_std"] }
+itertools = { version = "0.10.1", default-features = false, features = [
+  "use_std",
+] }
 once_cell = { version = "1.8.0", default-features = false }
 rand = { version = "0.8.4", default-features = false }
-reqwest = { version = "^0.11.7", default-features = false, features = [ "json" ] }
+reqwest = { version = "^0.11.7", default-features = false, features = ["json"] }
 semver = { version = "1.0.4", default-features = false, features = ["std"] }
 serde = { version = "1.0.130", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.59", default-features = false }
-structopt = { version = "0.3", default-features = false }
+clap = { version = "3.0.6", features = ["derive"] }
 tempfile = { version = "3.2.0", default-features = false }
 thiserror = { version = "1.0.29", default-features = false }
-tokio = { version = "1.11.0", features = [ "full" ] }
+tokio = { version = "1.11.0", features = ["full"] }
 url = { version = "2.2.2", default-features = false }
 sha2 = { version = "0.9.8", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }

--- a/src/svm/main.rs
+++ b/src/svm/main.rs
@@ -1,27 +1,27 @@
+use clap::Parser;
 use dialoguer::Input;
 use semver::Version;
-use structopt::StructOpt;
 
 use std::collections::HashSet;
 
 mod print;
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "solc-vm", about = "Solc version manager")]
+#[derive(Debug, Parser)]
+#[clap(name = "solc-vm", about = "Solc version manager")]
 enum SolcVm {
-    #[structopt(about = "List all versions of Solc")]
+    #[clap(about = "List all versions of Solc")]
     List,
-    #[structopt(about = "Install Solc versions")]
+    #[clap(about = "Install Solc versions")]
     Install { versions: Vec<String> },
-    #[structopt(about = "Use a Solc version")]
+    #[clap(about = "Use a Solc version")]
     Use { version: String },
-    #[structopt(about = "Remove a Solc version")]
+    #[clap(about = "Remove a Solc version")]
     Remove { version: String },
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let opt = SolcVm::from_args();
+    let opt = SolcVm::parse();
 
     svm_lib::setup_home()?;
 


### PR DESCRIPTION
structopt uses an old version of clap and it causes some trouble with downstream dependencies (e.g. foundry)