### PR TITLE
feat: add support for linux aarch64 binaries

### DIFF
--- a/list/linux-aarch64.json
+++ b/list/linux-aarch64.json
@@ -1,0 +1,221 @@
+{
+	"builds": [
+		{
+			"version": "0.5.0",
+			"sha256": "e54015fff10f033f44ced556eaa6a80ae3db0c3af791906c612f7503860ca68b"
+		},
+		{
+			"version": "0.5.1",
+			"sha256": "28f2bba1bd0398aec3d7b1df6b491222f9a16762b60bacafc87dd3a9139d275f"
+		},
+		{
+			"version": "0.5.2",
+			"sha256": "02a36cb84b632571d216f9825e326d21284836013be7d5a584deea1740e0e02e"
+		},
+		{
+			"version": "0.5.3",
+			"sha256": "ad580ff59b4e9ae94acfb6b831424219a1cf5009b6d84273cf975fae7501bcaa"
+		},
+		{
+			"version": "0.5.9",
+			"sha256": "dd42208eef2228f2d0b271e763532c04752bd2ae6400e2267d79f539a324f048"
+		},
+		{
+			"version": "0.5.10",
+			"sha256": "ebaffdcd675436d66b3c3dc3381ec5b9931e693c9450edc9cb8182660570517c"
+		},
+		{
+			"version": "0.5.11",
+			"sha256": "199f2b0262f17b765734230a81223f3e6fe51d06578035a92c90eb01ecf8fb4a"
+		},
+		{
+			"version": "0.5.14",
+			"sha256": "04419520523675141a1b6875445fcd56407edab6b32d7df6de78a7b84d6e140a"
+		},
+		{
+			"version": "0.5.15",
+			"sha256": "c855a2c6fef622609f7adee4016091b85e1940d62bb1fc22bbb3c24dffeb6e54"
+		},
+		{
+			"version": "0.5.16",
+			"sha256": "a1e5dd4759d6dd277dc8d97bfa92d438f88dec1a7a8e8e38a802d50bb9b38c26"
+		},
+		{
+			"version": "0.5.17",
+			"sha256": "bb8c0f04202273d7b90d9b9ef738914f7b137a66273279f4fd2a41a79c236917"
+		},
+		{
+			"version": "0.6.0",
+			"sha256": "f3fd0f5b0dd8447bc195f395e7e6e5233fe4205e6fc4688e17b7e754548708c4"
+		},
+		{
+			"version": "0.6.1",
+			"sha256": "5b631b2686e4c1442a06a7baa8dcbf8b8af6fb05658f0a61a1498bc33f2ad143"
+		},
+		{
+			"version": "0.6.2",
+			"sha256": "25a089c15d0cba70bf786034d0e5bfd53300c49ba44a0ede3e3d2ac031867f82"
+		},
+		{
+			"version": "0.6.3",
+			"sha256": "75a6b01bd5310e2136e437d1e0b4171f53e298e610d644e393a612959bf94f4b"
+		},
+		{
+			"version": "0.6.4",
+			"sha256": "f95ec6387cb2b0b0ac560096a0234e570964fccb6d1dacc949bffc63960dba37"
+		},
+		{
+			"version": "0.6.5",
+			"sha256": "a7799b6b682e5586716aea73f1b67e6e7168c3f49e6ad15c0e5d1ea226607c79"
+		},
+		{
+			"version": "0.6.6",
+			"sha256": "d9919bcef83243e227fe34c3fc234e5eb79c380d526854b3b214187e51827bba"
+		},
+		{
+			"version": "0.6.7",
+			"sha256": "3f717c22999d4a205c49016b911035d767ceae1ccfe9a651fe34878f692bffcc"
+		},
+		{
+			"version": "0.6.8",
+			"sha256": "7489255dc133520a1a60dd4bef43dcd2b079e7fefb5070d2696d01417e60c7ee"
+		},
+		{
+			"version": "0.6.9",
+			"sha256": "d5882750a211eab1bd23a20eda4a099b74c768facba756e6203bea9d316507f2"
+		},
+		{
+			"version": "0.6.10",
+			"sha256": "9cdb8849ff554a0dd440b5a5f0f7789dc71e1c3419b7ee39e4dbbfd1e1c4ad8f"
+		},
+		{
+			"version": "0.6.11",
+			"sha256": "c522f69054671ce6c5f211011f872d43a73bd7cc1e1c9f022b79d4827d92b55c"
+		},
+		{
+			"version": "0.6.12",
+			"sha256": "fa1fee2b4d5ed35c2467f4a5988742a59743bac2ea646a71de76ee010ebc1d4f"
+		},
+		{
+			"version": "0.7.0",
+			"sha256": "2c4a981f5afe832f0ad8f7934fa87cb6148555767b0c48ac64c5b9df8546c31b"
+		},
+		{
+			"version": "0.7.1",
+			"sha256": "e490228da3e1329a824add36a055970189ce396cee8fa01311a6a7c33b8d8509"
+		},
+		{
+			"version": "0.7.2",
+			"sha256": "725a41b8d1e4231764bc24e20ad7a0484da3eafe3fd08c2cec4da7337cabdb7d"
+		},
+		{
+			"version": "0.7.3",
+			"sha256": "2c34760fa59c9357f4da6da7e20ea80adfef5b84b0b1fec8fce3720493888658"
+		},
+		{
+			"version": "0.7.4",
+			"sha256": "c201c8ea7aca9d3aae77f5bc92aee34bba4da36f11cd75d2e9c260e116e6e748"
+		},
+		{
+			"version": "0.7.5",
+			"sha256": "54627363259db357173b6eec1c514d03cd635144c40e7a25b3ca75b63720c657"
+		},
+		{
+			"version": "0.7.6",
+			"sha256": "b436bafdfd8e3181ed1158d1a298d16953f26956bea01a56ebb553d401c7d7f1"
+		},
+		{
+			"version": "0.8.0",
+			"sha256": "661d3050a332f0cb7653490cc8849c8a004f03f0d120d1467e6c34284ef9f429"
+		},
+		{
+			"version": "0.8.1",
+			"sha256": "c8216f86880aec58ec16b10671517acd4c45fc067e24a34e2d817126da41674e"
+		},
+		{
+			"version": "0.8.2",
+			"sha256": "27f5c746ce62893999bdf3ccf715c88a683649f1d47fce7e4daca857aa300fe0"
+		},
+		{
+			"version": "0.8.3",
+			"sha256": "ee4a9d2d5015d06814394403a1d9e3f7c7eae005fe0562912fc4828dc24c48a1"
+		},
+		{
+			"version": "0.8.4",
+			"sha256": "f5c8ed0de02862215afce17935f4466aa8d02f70e3329384cbeb25f39be075f8"
+		},
+		{
+			"version": "0.8.5",
+			"sha256": "11bf06141d2ac9e1ceed654cbf02ee64cab2a7bc1bfcd85b4ef574d4198d5a4f"
+		},
+		{
+			"version": "0.8.6",
+			"sha256": "38a3dae819f59d3ad161c42684ae3525603dc78552ca948602ae2658d13f2842"
+		},
+		{
+			"version": "0.8.7",
+			"sha256": "ab90240046f2424063eab576fe1c1be176c56b7e8833db2be86b2813bfb44176"
+		},
+		{
+			"version": "0.8.8",
+			"sha256": "d2cb6d523f460ff06b823b89a2369f3f01400184fc972dd5f825bf96867d3ee3"
+		},
+		{
+			"version": "0.8.9",
+			"sha256": "9fe4548a3eb8d121efba6e50f272572a736c0a5f5344021f88c5ffdc3c995e8b"
+		},
+		{
+			"version": "0.8.10",
+			"sha256": "441e42fb8109db9a2ffb8e7e61502bc3f7f43daaf0c4c03ef0856937df13709f"
+		},
+		{
+			"version": "0.8.11",
+			"sha256": "e72c0462c5bf00388b8663a32542db8d4abdbd7192d16575dd31f3fbd58f4b2a"
+		}
+	],
+	"releases": {
+		"0.5.0": "solc-v0.5.0",
+		"0.5.1": "solc-v0.5.1",
+		"0.5.2": "solc-v0.5.2",
+		"0.5.3": "solc-v0.5.3",
+		"0.5.9": "solc-v0.5.9",
+		"0.5.10": "solc-v0.5.10",
+		"0.5.11": "solc-v0.5.11",
+		"0.5.14": "solc-v0.5.14",
+		"0.5.15": "solc-v0.5.15",
+		"0.5.16": "solc-v0.5.16",
+		"0.5.17": "solc-v0.5.17",
+		"0.6.0": "solc-v0.6.0",
+		"0.6.1": "solc-v0.6.1",
+		"0.6.2": "solc-v0.6.2",
+		"0.6.3": "solc-v0.6.3",
+		"0.6.4": "solc-v0.6.4",
+		"0.6.5": "solc-v0.6.5",
+		"0.6.6": "solc-v0.6.6",
+		"0.6.7": "solc-v0.6.7",
+		"0.6.8": "solc-v0.6.8",
+		"0.6.9": "solc-v0.6.9",
+		"0.6.10": "solc-v0.6.10",
+		"0.6.11": "solc-v0.6.11",
+		"0.6.12": "solc-v0.6.12",
+		"0.7.0": "solc-v0.7.0",
+		"0.7.1": "solc-v0.7.1",
+		"0.7.2": "solc-v0.7.2",
+		"0.7.3": "solc-v0.7.3",
+		"0.7.4": "solc-v0.7.4",
+		"0.7.5": "solc-v0.7.5",
+		"0.7.6": "solc-v0.7.6",
+		"0.8.0": "solc-v0.8.0",
+		"0.8.1": "solc-v0.8.1",
+		"0.8.2": "solc-v0.8.2",
+		"0.8.3": "solc-v0.8.3",
+		"0.8.4": "solc-v0.8.4",
+		"0.8.5": "solc-v0.8.5",
+		"0.8.6": "solc-v0.8.6",
+		"0.8.7": "solc-v0.8.7",
+		"0.8.8": "solc-v0.8.8",
+		"0.8.9": "solc-v0.8.9",
+		"0.8.10": "solc-v0.8.10",
+		"0.8.11": "solc-v0.8.11"
+	}
+}

--- a/list/linux-arm64-old.json
+++ b/list/linux-arm64-old.json
@@ -1,0 +1,56 @@
+{
+	"builds": [
+		{
+                    "version": "0.4.9",
+                    "sha256": "0x71da154585e0c9048445b39b3662b421d20814cc68482b6b072aae2e541a4c74"
+                },
+                {
+                    "version": "0.4.8",
+                    "sha256": "0xee76039f933938cb5c14bf3fc4754776aa3e5c4c88420413da4c0c13731b8ffe"
+                },
+                {
+                    "version": "0.4.7",
+                    "sha256": "0xe1affb6e13dee7b14039f8eb1a52343f5fdc56169023e0f7fc339dfc25ad2b3d"
+                },
+                {
+                    "version": "0.4.6",
+                    "sha256": "0x0525d7b95549db6c913edb3c1b0c26d2db81e64b03f8352261df1b2ad696a65e"
+                },
+                {
+                    "version": "0.4.5",
+                    "sha256": "0x6f46ab7747d7de1b75907e539e6e19be201680e64ce99b583c6356e4e7897406"
+                },
+                {
+                    "version": "0.4.4",
+                    "sha256": "0x25d148e9c1052631a930bfbe8e4e3d9dae8de7659f8d3ea659a3ef139cd5e2c9"
+                },
+                {
+                    "version": "0.4.3",
+                    "sha256": "0x1dc7ef0b4aab472299e77b39c7465cd5ed4609a759b52ce1a93f2d54395da73a"
+                },
+                {
+                    "version": "0.4.2",
+                    "sha256": "0x891d0b2d3a636ff40924802a6f5beb1ecbc42d5d0d0bfecbbb148b561c861fb9"
+                },
+                {
+                    "version": "0.4.1",
+                    "sha256": "0xa0c06d0c6a14c66ddeca1f065461fb0024de89421c1809a1b103b55c94e30860"
+                },
+                {
+                    "version": "0.4.0",
+                    "sha256": "0xe26d188284763684f3cf6d4900b72f7e45a050dd2b2707320273529d033cfd47"
+                }
+	],
+	"releases": {
+		"0.4.9": "solc-v0.4.9",
+                "0.4.8": "solc-v0.4.8",
+                "0.4.7": "solc-v0.4.7",
+                "0.4.6":"solc-v0.4.6",
+                "0.4.5": "solc-v0.4.5",
+                "0.4.4":"solc-v0.4.4",
+                "0.4.3":"solc-v0.4.3",
+                "0.4.2":"solc-v0.4.2",
+                "0.4.1": "solc-v0.4.1",
+                "0.4.0": "solc-v0.4.0"
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,12 +180,30 @@ fn setup_version(version: &str) -> Result<(), SolcVmError> {
 
 #[cfg(test)]
 mod tests {
-    use crate::releases::all_releases;
+    use crate::{
+        platform::Platform,
+        releases::{all_releases, artifact_url},
+    };
     use rand::seq::SliceRandom;
+    use reqwest::Url;
     use std::process::Command;
     use std::process::Stdio;
 
     use super::*;
+
+    #[tokio::test]
+    async fn test_artifact_url() {
+        let version = Version::new(0, 5, 0);
+        let artifact = "solc-v0.5.0";
+        assert_eq!(
+            artifact_url(Platform::LinuxAarch64, &version, artifact).unwrap(),
+            Url::parse(&format!(
+                "https://github.com/nikitastupin/solc/raw/main/linux/aarch64/{}",
+                artifact
+            ))
+            .unwrap(),
+        )
+    }
 
     #[tokio::test]
     async fn test_install() {
@@ -196,7 +214,7 @@ mod tests {
             .into_keys()
             .collect::<Vec<Version>>();
         let rand_version = versions.choose(&mut rand::thread_rng()).unwrap();
-        assert!(install(&rand_version).await.is_ok());
+        assert!(install(rand_version).await.is_ok());
     }
 
     #[tokio::test]

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -4,6 +4,7 @@ use std::env;
 #[derive(Clone, Debug, PartialEq)]
 pub enum Platform {
     LinuxAmd64,
+    LinuxAarch64,
     MacOsAmd64,
     WindowsAmd64,
     Unsupported,
@@ -13,6 +14,7 @@ impl ToString for Platform {
     fn to_string(&self) -> String {
         match self {
             Platform::LinuxAmd64 => "linux-amd64".to_string(),
+            Platform::LinuxAarch64 => "linux-aarch64".to_string(),
             Platform::MacOsAmd64 => "macosx-amd64".to_string(),
             Platform::WindowsAmd64 => "windows-amd64".to_string(),
             Platform::Unsupported => "Unsupported-platform".to_string(),
@@ -24,6 +26,7 @@ impl ToString for Platform {
 pub fn platform() -> Platform {
     match (env::consts::OS, env::consts::ARCH) {
         ("linux", "x86_64") => Platform::LinuxAmd64,
+        ("linux", "aarch64") => Platform::LinuxAarch64,
         // NOTE: Relaxed requirement on target architecture here
         // to support M1 macs with Rosetta
         ("macos", _) => Platform::MacOsAmd64,


### PR DESCRIPTION
Adding support for linux aarch64 architecture.

`solc` binaries fetched from https://github.com/nikitastupin/solc/tree/main/linux/aarch64