### PR TITLE
fix: pin arm64 solc commit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,7 @@ mod tests {
         assert_eq!(
             artifact_url(Platform::LinuxAarch64, &version, artifact).unwrap(),
             Url::parse(&format!(
-                "https://github.com/nikitastupin/solc/raw/main/linux/aarch64/{}",
+                "https://github.com/nikitastupin/solc/raw/3890b86a62fe6b8efd2f643f4adcd854f478b623/linux/aarch64/{}",
                 artifact
             ))
             .unwrap(),

--- a/src/releases.rs
+++ b/src/releases.rs
@@ -27,7 +27,7 @@ static OLD_SOLC_RELEASES: Lazy<Releases> = Lazy::new(|| {
 });
 
 static LINUX_AARCH64_URL_PREFIX: &str =
-    "https://github.com/nikitastupin/solc/raw/main/linux/aarch64";
+    "https://github.com/nikitastupin/solc/raw/3890b86a62fe6b8efd2f643f4adcd854f478b623/linux/aarch64";
 
 static LINUX_AARCH64_RELEASES: Lazy<Releases> = Lazy::new(|| {
     serde_json::from_reader(


### PR DESCRIPTION
this avoids potential issues in the future where the solc binaries in the repo
get updated to a malicious binary

pin is https://github.com/nikitastupin/solc/tree/3890b86a62fe6b8efd2f643f4adcd854f478b623