### PR TITLE
chore: export blocking_all_releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,7 +1098,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "svm-rs"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "svm-rs"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2018"
 authors = ["Rohit Narurkar <rohit.narurkar@protonmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ mod platform;
 pub use platform::platform;
 
 mod releases;
-pub use releases::{all_releases, Releases};
+pub use releases::{all_releases, blocking_all_releases, Releases};
 
 static INSTALL_TIMEOUT: Duration = Duration::from_secs(10);
 static LOCKFILE_CHECK_INTERVAL: Duration = Duration::from_millis(500);


### PR DESCRIPTION
reexports `blocking_all_releases` and bumps version