### PR TITLE
fix: macos M1 releases in `blocking_all_releases`

### DIFF
--- a/src/releases.rs
+++ b/src/releases.rs
@@ -124,7 +124,7 @@ pub fn blocking_all_releases(platform: Platform) -> Result<Releases, SolcVmError
     if platform == Platform::LinuxAarch64 {
         return Ok(LINUX_AARCH64_RELEASES.clone());
     }
-    
+
     if platform == Platform::MacOsAarch64 {
         return Ok(MACOS_AARCH64_RELEASES.clone());
     }

--- a/src/releases.rs
+++ b/src/releases.rs
@@ -124,6 +124,10 @@ pub fn blocking_all_releases(platform: Platform) -> Result<Releases, SolcVmError
     if platform == Platform::LinuxAarch64 {
         return Ok(LINUX_AARCH64_RELEASES.clone());
     }
+    
+    if platform == Platform::MacOsAarch64 {
+        return Ok(MACOS_AARCH64_RELEASES.clone());
+    }
 
     let releases = reqwest::blocking::get(format!(
         "{}/{}/list.json",


### PR DESCRIPTION
Returns the macOS AArch64 releases in `blocking_all_releases` as we do in `all_releases`.