### PR TITLE
[p0] fix: update solc checksums for prod builds

### DIFF
--- a/list/macosx-aarch64.json
+++ b/list/macosx-aarch64.json
@@ -2,25 +2,30 @@
   "builds": [
     {
       "version": "0.8.12",
-      "sha256": "afb3aa3471f8defb21610d1a3ee56aabdea1c71dcc5ccb5813ac3e3cba208351"
+      "sha256": "7b3faedb17c1709641877d1a7e7d54eaf713929fadbc8be5cc9d9e24ab8b9cc7"
     },
     {
       "version": "0.8.11",
-      "sha256": "519d8bde19c8a64674d3113a4d47a16702ae1bf052375c78cb639f5932758ccc"
+      "sha256": "5fd03cb7a9d3959ea338b8c44f14ee81151fb30b2a763b7afc30c55ad07f4fe5"
     },
     {
       "version": "0.8.10",
-      "sha256": "760715f08bf6921ffffd5c3535f99d5dc8e6f766b57e1dd93649f5514aeaa3eb"
+      "sha256": "93ea87034fe0af3b2a84ccb9f2c075e21a05bb45d70ca8c72d21aabedae65d0e"
     },
     {
       "version": "0.8.9",
-      "sha256": "bf7d3e1db1d5f1f6eaf8c82abd2751b32f2961b5fc8e03c2e2146c38574f2993"
+      "sha256": "5996fe80c8a1ac28f6010cea3ccbb1c2bbd0e25391e52c62839b6fa05d1e7eac"
+    },
+    {
+      "version": "0.8.8",
+      "sha256": "5770c0f421646fae964c55823df13b42655001001916591cad4720750254b657"
     }
   ],
   "releases": {
     "0.8.12": "solc-v0.8.12",
     "0.8.11": "solc-v0.8.11",
     "0.8.10": "solc-v0.8.10",
-    "0.8.9": "solc-v0.8.9"
+    "0.8.9": "solc-v0.8.9",
+    "0.8.8": "solc-v0.8.8"
   }
 }

--- a/src/releases.rs
+++ b/src/releases.rs
@@ -249,8 +249,8 @@ mod tests {
 
     #[test]
     fn test_macos_aarch64() {
-        assert_eq!(MACOS_AARCH64_RELEASES.releases.len(), 4);
-        assert_eq!(MACOS_AARCH64_RELEASES.builds.len(), 4);
+        assert_eq!(MACOS_AARCH64_RELEASES.releases.len(), 5);
+        assert_eq!(MACOS_AARCH64_RELEASES.builds.len(), 5);
     }
 
     #[tokio::test]


### PR DESCRIPTION
this was done [here](https://github.com/roynalnaruto/solc-builds/commit/d1388e554684c5a10954d0c80182e671c4fc2ade) but the change was not ported over. this must be merged ASAP as otherwise all checksums checks will fail

this is not an ideal solution as we need to keep the 2 repos in sync, ideally only 1 checksum file should be used