### PR TITLE
feat(builds): add svm-builds crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "build_const"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
+
+[[package]]
 name = "bumpalo"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.73"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -1124,6 +1130,17 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "svm-rs-builds"
+version = "0.1.0"
+dependencies = [
+ "build_const",
+ "hex",
+ "semver",
+ "serde_json",
+ "svm-rs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,7 @@ openssl = ["reqwest/native-tls"]
 rustls = ["reqwest/rustls-tls"]
 sha2-asm = ["sha2/asm"]
 blocking = ["reqwest/blocking"]
+
+
+[workspace]
+members = ["svm-builds"]

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,4 +1,5 @@
-use std::env;
+use std::fmt::Formatter;
+use std::{env, fmt};
 
 /// Types of supported platforms.
 #[derive(Clone, Debug, PartialEq)]
@@ -11,16 +12,17 @@ pub enum Platform {
     Unsupported,
 }
 
-impl ToString for Platform {
-    fn to_string(&self) -> String {
-        match self {
-            Platform::LinuxAmd64 => "linux-amd64".to_string(),
-            Platform::LinuxAarch64 => "linux-aarch64".to_string(),
-            Platform::MacOsAmd64 => "macosx-amd64".to_string(),
-            Platform::MacOsAarch64 => "macosx-aarch64".to_string(),
-            Platform::WindowsAmd64 => "windows-amd64".to_string(),
-            Platform::Unsupported => "Unsupported-platform".to_string(),
-        }
+impl fmt::Display for Platform {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Platform::LinuxAmd64 => "linux-amd64",
+            Platform::LinuxAarch64 => "linux-aarch64",
+            Platform::MacOsAmd64 => "macosx-amd64",
+            Platform::MacOsAarch64 => "macosx-aarch64",
+            Platform::WindowsAmd64 => "windows-amd64",
+            Platform::Unsupported => "Unsupported-platform",
+        };
+        f.write_str(s)
     }
 }
 

--- a/src/releases.rs
+++ b/src/releases.rs
@@ -137,7 +137,7 @@ pub fn blocking_all_releases(platform: Platform) -> Result<Releases, SolcVmError
         let mut releases = reqwest::blocking::get(format!(
             "{}/{}/list.json",
             SOLC_RELEASES_URL,
-            Platform::MacOsAmd64.to_string(),
+            Platform::MacOsAmd64,
         ))?
         .json::<Releases>()?;
         releases.builds = releases
@@ -151,12 +151,8 @@ pub fn blocking_all_releases(platform: Platform) -> Result<Releases, SolcVmError
         return Ok(releases);
     }
 
-    let releases = reqwest::blocking::get(format!(
-        "{}/{}/list.json",
-        SOLC_RELEASES_URL,
-        platform.to_string()
-    ))?
-    .json::<Releases>()?;
+    let releases = reqwest::blocking::get(format!("{}/{}/list.json", SOLC_RELEASES_URL, platform))?
+        .json::<Releases>()?;
     Ok(unified_releases(releases, platform))
 }
 
@@ -181,7 +177,7 @@ pub async fn all_releases(platform: Platform) -> Result<Releases, SolcVmError> {
         let mut releases = get(format!(
             "{}/{}/list.json",
             SOLC_RELEASES_URL,
-            Platform::MacOsAmd64.to_string(),
+            Platform::MacOsAmd64,
         ))
         .await?
         .json::<Releases>()
@@ -197,14 +193,10 @@ pub async fn all_releases(platform: Platform) -> Result<Releases, SolcVmError> {
         return Ok(releases);
     }
 
-    let releases = get(format!(
-        "{}/{}/list.json",
-        SOLC_RELEASES_URL,
-        platform.to_string()
-    ))
-    .await?
-    .json::<Releases>()
-    .await?;
+    let releases = get(format!("{}/{}/list.json", SOLC_RELEASES_URL, platform))
+        .await?
+        .json::<Releases>()
+        .await?;
 
     Ok(unified_releases(releases, platform))
 }
@@ -268,7 +260,7 @@ pub fn artifact_url(
             return Ok(Url::parse(&format!(
                 "{}/{}/{}",
                 SOLC_RELEASES_URL,
-                Platform::MacOsAmd64.to_string(),
+                Platform::MacOsAmd64,
                 artifact,
             ))?);
         }
@@ -276,9 +268,7 @@ pub fn artifact_url(
 
     Ok(Url::parse(&format!(
         "{}/{}/{}",
-        SOLC_RELEASES_URL,
-        platform.to_string(),
-        artifact
+        SOLC_RELEASES_URL, platform, artifact
     ))?)
 }
 

--- a/svm-builds/Cargo.toml
+++ b/svm-builds/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "svm-rs-builds"
+version = "0.1.0"
+edition = "2021"
+authors = ["Matthias Seitz <matthias.seitz@outlook.de>", "Rohit Narurkar <rohit.narurkar@protonmail.com>"]
+license = "MIT OR Apache-2.0"
+description = """
+Solidity-Compiler (Solc) builds.
+"""
+readme = "../README.md"
+repository = "https://github.com/roynalnaruto/svm-rs"
+homepage = "https://github.com/roynalnaruto/svm-rs"
+build = "build.rs"
+
+[build-dependencies]
+build_const = "0.2.2"
+svm = { package = "svm-rs", path = "..", features = ["blocking"]}
+semver = { version = "1.0.4", default-features = false, features = ["std", "serde"] }
+hex = "0.4.3"
+serde_json = "1.0.79"
+
+[dependencies]
+build_const = "0.2.2"
+hex = "0.4.3"
+semver = { version = "1.0.4", default-features = false, features = ["std", "serde"] }

--- a/svm-builds/build.rs
+++ b/svm-builds/build.rs
@@ -1,0 +1,89 @@
+use semver::Version;
+use svm::Releases;
+
+fn version_const_name(version: &Version) -> String {
+    format!(
+        "SOLC_VERSION_{}_{}_{}",
+        version.major, version.minor, version.patch
+    )
+}
+
+/// Adds build info related constants
+fn add_build_info_constants(writer: &mut build_const::ConstValueWriter, releases: &Releases) {
+    let mut version_idents = Vec::with_capacity(releases.builds.len());
+    let mut checksum_match_arms = Vec::with_capacity(releases.builds.len());
+
+    for build in releases.builds.iter() {
+        let version_name = version_const_name(&build.version);
+
+        writer.add_value_raw(
+            &version_name,
+            "semver::Version",
+            &format!(
+                "semver::Version::new({},{},{})",
+                build.version.major, build.version.minor, build.version.patch
+            ),
+        );
+        version_idents.push(version_name);
+
+        let sha256 = hex::encode(&build.sha256);
+        let checksum_name = format!(
+            "SOLC_VERSION_{}_{}_{}_CHECKSUM",
+            build.version.major, build.version.minor, build.version.patch
+        );
+
+        writer.add_value(&checksum_name, "&str", sha256);
+        checksum_match_arms.push(format!(
+            "({},{},{})  => {}",
+            build.version.major, build.version.minor, build.version.patch, checksum_name
+        ));
+    }
+
+    let raw_static_array = format!(
+        r#"
+/// All available releases for {}
+pub static ALL_SOLC_VERSIONS : [semver::Version; {}] = [
+    {}  ];
+    "#,
+        svm::platform(),
+        version_idents.len(),
+        version_idents.join(",\n")
+    );
+    writer.add_raw(&raw_static_array);
+
+    let get_check_sum_fn = format!(
+        r#"
+/// Get the checksum of a solc version's binary if it exists.
+pub fn get_checksum(version: &semver::Version) -> Option<Vec<u8>> {{
+    let checksum = match (version.major, version.minor, version.patch) {{
+        {},
+        _ => return None
+    }};
+    Some(hex::decode(checksum).expect("valid hex;"))
+}}
+    "#,
+        checksum_match_arms.join(",\n")
+    );
+
+    writer.add_raw(&get_check_sum_fn);
+}
+
+fn main() {
+    let releases = svm::blocking_all_releases(svm::platform()).expect("Failed to fetch releases");
+
+    let mut writer = build_const::ConstWriter::for_build("builds")
+        .unwrap()
+        .finish_dependencies();
+
+    add_build_info_constants(&mut writer, &releases);
+
+    let release_json = serde_json::to_string(&releases).unwrap();
+    writer.add_raw(&format!(
+        r#"
+/// JSON release list
+pub static RELEASE_LIST_JSON : &str = {}"{}"{};"#,
+        "r#", release_json, "#"
+    ));
+
+    writer.finish();
+}

--- a/svm-builds/src/lib.rs
+++ b/svm-builds/src/lib.rs
@@ -1,0 +1,3 @@
+//! Contains all solc builds for the platform it was compiled with
+
+build_const::build_const!("builds");


### PR DESCRIPTION
# Motivation
Embed Release information in a crate so we don't need to query `svm::releases` all the time

# Solution

Add a new crate (svm-builds) that fetches all available releases during build and generates constants

expanded output:

```rust
pub const SOLC_VERSION_0_3_6: semver::Version = semver::Version::new(0, 3, 6);
pub const SOLC_VERSION_0_3_6_CHECKSUM: &str =
    "02d581b5b373d8160b9e75d690dd2ee898c3e0f6a39bbda54cd0698224c09df4";
pub const SOLC_VERSION_0_4_0: semver::Version = semver::Version::new(0, 4, 0);
pub const SOLC_VERSION_0_4_0_CHECKSUM: &str =
    "bba6e2c33935259c478060501a7fb0ee1db4b0c56567356c9d01b6ec0491a558";
pub const SOLC_VERSION_0_4_1: semver::Version = semver::Version::new(0, 4, 1);
pub const SOLC_VERSION_0_4_1_CHECKSUM: &str =
    "2de730163c80670b2f4c1ef78dc77ab13f757aad1ead044761821293275c382b";
pub const SOLC_VERSION_0_4_2: semver::Version = semver::Version::new(0, 4, 2);
pub const SOLC_VERSION_0_4_2_CHECKSUM: &str =
    "9882bb966b82c0f4847735dba20b517118cf5408ed2a872485750f6ff26cf98b";
pub const SOLC_VERSION_0_4_3: semver::Version = semver::Version::new(0, 4, 3);
pub const SOLC_VERSION_0_4_3_CHECKSUM: &str =
    "3ac02a93f4c7c20b9f17b6038af25b41acb8cfe178040be0f2246adc8bb8fe0a";
pub const SOLC_VERSION_0_4_4: semver::Version = semver::Version::new(0, 4, 4);
pub const SOLC_VERSION_0_4_4_CHECKSUM: &str =
    "38ceeea801b5952d74bdb79ae5bc6bbb4c187ee5941e2701de388fdf95322f58";
pub const SOLC_VERSION_0_4_5: semver::Version = semver::Version::new(0, 4, 5);
pub const SOLC_VERSION_0_4_5_CHECKSUM: &str =
    "003b09c2f255d2a40c2b2a1798192f92e6a3f1b35bda1a35ba66675919be1555";
pub const SOLC_VERSION_0_4_6: semver::Version = semver::Version::new(0, 4, 6);
pub const SOLC_VERSION_0_4_6_CHECKSUM: &str =
    "aef1ebf2d2783a31742a612461f13e0ffc656c4a5ce25a0eeb747186ce03b276";
pub const SOLC_VERSION_0_4_7: semver::Version = semver::Version::new(0, 4, 7);
pub const SOLC_VERSION_0_4_7_CHECKSUM: &str =
    "fc386d2547b6f764a0c1139487ed1d4a19e334c510a727614ff8ebeb1bd01a93";
pub const SOLC_VERSION_0_4_8: semver::Version = semver::Version::new(0, 4, 8);
pub const SOLC_VERSION_0_4_8_CHECKSUM: &str =
    "ebb64b8b8dd465bd53a52fa7063569115df176c7561ac4feb47004513e1df74b";
pub const SOLC_VERSION_0_4_9: semver::Version = semver::Version::new(0, 4, 9);
pub const SOLC_VERSION_0_4_9_CHECKSUM: &str =
    "a5b4227ed259c474426d8a2ef380606766aa8ba7f65487ab177139b3a51f0dee";
pub const SOLC_VERSION_0_4_10: semver::Version = semver::Version::new(0, 4, 10);
pub const SOLC_VERSION_0_4_10_CHECKSUM: &str =
    "40f179e4d27201ab726669dd26d594cfe10bf4dd6117495ee49d26f0dda9ef42";
pub const SOLC_VERSION_0_4_11: semver::Version = semver::Version::new(0, 4, 11);
pub const SOLC_VERSION_0_4_11_CHECKSUM: &str =
    "287eab0187dd4bdec50226f3173526bd8d247adeebdf64bc0b7448711abbea61";
pub const SOLC_VERSION_0_4_12: semver::Version = semver::Version::new(0, 4, 12);
pub const SOLC_VERSION_0_4_12_CHECKSUM: &str =
    "65cc92c918d6334f533a7596f62916825fc722b2a7a235729ed87cfbec622bcd";
pub const SOLC_VERSION_0_4_13: semver::Version = semver::Version::new(0, 4, 13);
pub const SOLC_VERSION_0_4_13_CHECKSUM: &str =
    "701eebf0e37d172cb829dc1e65c74a46b3b96737f3866758f9894696a639b6b7";
pub const SOLC_VERSION_0_4_14: semver::Version = semver::Version::new(0, 4, 14);
pub const SOLC_VERSION_0_4_14_CHECKSUM: &str =
    "a4ef22d9d36e75151bdd64720e69eddf57500883dd623c57805edb5ccb644a89";
pub const SOLC_VERSION_0_4_15: semver::Version = semver::Version::new(0, 4, 15);
pub const SOLC_VERSION_0_4_15_CHECKSUM: &str =
    "e449a4980db4ff18e7ffe704b40083cded96cccf33986bf6a6bb6fe925eb86c0";
pub const SOLC_VERSION_0_4_16: semver::Version = semver::Version::new(0, 4, 16);
pub const SOLC_VERSION_0_4_16_CHECKSUM: &str =
    "a24512aee16652c4469979715bbdcaa6c4afabb94b717bb40980e4b2d25c4709";
pub const SOLC_VERSION_0_4_17: semver::Version = semver::Version::new(0, 4, 17);
pub const SOLC_VERSION_0_4_17_CHECKSUM: &str =
    "458c3e2de2ffe609b79d9cdc4eb3080d6ed7662ef1bdd7c8a03fb18f1ca9a137";
pub const SOLC_VERSION_0_4_18: semver::Version = semver::Version::new(0, 4, 18);
pub const SOLC_VERSION_0_4_18_CHECKSUM: &str =
    "dddc86683d12d0f016b5d5799ed84f6f2a79f667ebb932b9a8e6bfe9a48c3190";
pub const SOLC_VERSION_0_4_19: semver::Version = semver::Version::new(0, 4, 19);
pub const SOLC_VERSION_0_4_19_CHECKSUM: &str =
    "ace5107a68fa75634e26848d6d208b808a76cc4f9262e53e8a3622bcefd4dcaf";
pub const SOLC_VERSION_0_4_20: semver::Version = semver::Version::new(0, 4, 20);
pub const SOLC_VERSION_0_4_20_CHECKSUM: &str =
    "47425e338b9461d3e6498a0b0d5c2b9cc7cf998e4aa69126ea9f64c0a176e605";
pub const SOLC_VERSION_0_4_21: semver::Version = semver::Version::new(0, 4, 21);
pub const SOLC_VERSION_0_4_21_CHECKSUM: &str =
    "e035cb9a81b5e3e11a7b99ead6f51a3ef7729794eebee470a964e2c08e30b857";
pub const SOLC_VERSION_0_4_22: semver::Version = semver::Version::new(0, 4, 22);
pub const SOLC_VERSION_0_4_22_CHECKSUM: &str =
    "a9341add7a4f01c52dbb36bb4028104676c684b0b6003a2cd9dd84a2a9802b59";
pub const SOLC_VERSION_0_4_23: semver::Version = semver::Version::new(0, 4, 23);
pub const SOLC_VERSION_0_4_23_CHECKSUM: &str =
    "502eddb177f9268d79b1e05e6acfb2f229471823bf6711eff411d2a23e8cc0b1";
pub const SOLC_VERSION_0_4_24: semver::Version = semver::Version::new(0, 4, 24);
pub const SOLC_VERSION_0_4_24_CHECKSUM: &str =
    "7034c4048bc713d5c14cdd6681953c736e2adbdb9174f8bfbfb6a097109ffaaa";
pub const SOLC_VERSION_0_4_25: semver::Version = semver::Version::new(0, 4, 25);
pub const SOLC_VERSION_0_4_25_CHECKSUM: &str =
    "9dd7686975200be71ce731f153823e7ea0d68106f3354ea16fecd5975f5c98b7";
pub const SOLC_VERSION_0_4_26: semver::Version = semver::Version::new(0, 4, 26);
pub const SOLC_VERSION_0_4_26_CHECKSUM: &str =
    "bc956645b792dcbb8f820b8010a8d4ec1e188f7b40c6af951a436da4c13ae677";
pub const SOLC_VERSION_0_5_0: semver::Version = semver::Version::new(0, 5, 0);
pub const SOLC_VERSION_0_5_0_CHECKSUM: &str =
    "9fa663fc427e8e9613815ad6b83783b4e4cb10439f16ca0dcb12fc002c45ab5a";
pub const SOLC_VERSION_0_5_1: semver::Version = semver::Version::new(0, 5, 1);
pub const SOLC_VERSION_0_5_1_CHECKSUM: &str =
    "f2bad43386065684b4e15b86a175410f5d1e4d234b052cba44eb50f4c74b021f";
pub const SOLC_VERSION_0_5_2: semver::Version = semver::Version::new(0, 5, 2);
pub const SOLC_VERSION_0_5_2_CHECKSUM: &str =
    "9e7ee54f0bc2978fa8738b9603d636715a069d84771778d6195577bb91ecb9c8";
pub const SOLC_VERSION_0_5_3: semver::Version = semver::Version::new(0, 5, 3);
pub const SOLC_VERSION_0_5_3_CHECKSUM: &str =
    "03a6cfa2d74e57ea38eee83ce9a3ea37a6e50928d7f109e74b37cae31319af2b";
pub const SOLC_VERSION_0_5_4: semver::Version = semver::Version::new(0, 5, 4);
pub const SOLC_VERSION_0_5_4_CHECKSUM: &str =
    "32a8affa996d05c55257317cc700b9e5b4377d94919b59055564eb0b5f941773";
pub const SOLC_VERSION_0_5_5: semver::Version = semver::Version::new(0, 5, 5);
pub const SOLC_VERSION_0_5_5_CHECKSUM: &str =
    "7fc0600cc150020402c9539ec0ad584eb9271b2d0e0bff9e3b4d4ca672be3452";
pub const SOLC_VERSION_0_5_6: semver::Version = semver::Version::new(0, 5, 6);
pub const SOLC_VERSION_0_5_6_CHECKSUM: &str =
    "428f9c0873d88740242f6fc16a3ae6f91b35f73ddf7676b5d5b39687d9d9b7dc";
pub const SOLC_VERSION_0_5_7: semver::Version = semver::Version::new(0, 5, 7);
pub const SOLC_VERSION_0_5_7_CHECKSUM: &str =
    "a7d6b8e3cb22d90789a79b484b721fe02943f89e9b7e996863edd2d40ba7b524";
pub const SOLC_VERSION_0_5_8: semver::Version = semver::Version::new(0, 5, 8);
pub const SOLC_VERSION_0_5_8_CHECKSUM: &str =
    "9f383896c8506cd96ac5ef9c97d7ab1c385fb5f4772a5f3d2cf8715cae793554";
pub const SOLC_VERSION_0_5_9: semver::Version = semver::Version::new(0, 5, 9);
pub const SOLC_VERSION_0_5_9_CHECKSUM: &str =
    "92e3688207c0c2b86bd9d10088340e4a585e29e3a88d1cf79c2043f4f9f121c4";
pub const SOLC_VERSION_0_5_10: semver::Version = semver::Version::new(0, 5, 10);
pub const SOLC_VERSION_0_5_10_CHECKSUM: &str =
    "5082bb5c492ca35b68b0c3e24d5934b56d3add83f1400ba95654e8f163c741ff";
pub const SOLC_VERSION_0_5_11: semver::Version = semver::Version::new(0, 5, 11);
pub const SOLC_VERSION_0_5_11_CHECKSUM: &str =
    "0e8ee89ddb1096b81c34e11bdb5985822e749d3a9dc4e7218ba2474afa6400cb";
pub const SOLC_VERSION_0_5_12: semver::Version = semver::Version::new(0, 5, 12);
pub const SOLC_VERSION_0_5_12_CHECKSUM: &str =
    "3dfb97bc941492afaea7f404c3fb9c6fe215b3386aa6e0370791b571e4679548";
pub const SOLC_VERSION_0_5_13: semver::Version = semver::Version::new(0, 5, 13);
pub const SOLC_VERSION_0_5_13_CHECKSUM: &str =
    "68a344d9de40b0d7482089ee7748e43088c52e3b108480d801b34c64020beb48";
pub const SOLC_VERSION_0_5_14: semver::Version = semver::Version::new(0, 5, 14);
pub const SOLC_VERSION_0_5_14_CHECKSUM: &str =
    "8afa926b6bb8ad492fb25078b1dce09fd05faa5765e4e2b2672b3c99cf71eeb1";
pub const SOLC_VERSION_0_5_15: semver::Version = semver::Version::new(0, 5, 15);
pub const SOLC_VERSION_0_5_15_CHECKSUM: &str =
    "9e05051c3d42a49c8470cbed1f2bfa89fe76e930a9e5558c52ce5653cf794e25";
pub const SOLC_VERSION_0_5_16: semver::Version = semver::Version::new(0, 5, 16);
pub const SOLC_VERSION_0_5_16_CHECKSUM: &str =
    "9f6624e408497142bbd29efe0744ee25e445aeb7c932be401c0bc30478a6bb75";
pub const SOLC_VERSION_0_5_17: semver::Version = semver::Version::new(0, 5, 17);
pub const SOLC_VERSION_0_5_17_CHECKSUM: &str =
    "35be28f68488b71f1de66148f915b91d64e062900e4fc175bf2eb8fb948810bd";
pub const SOLC_VERSION_0_6_0: semver::Version = semver::Version::new(0, 6, 0);
pub const SOLC_VERSION_0_6_0_CHECKSUM: &str =
    "37beed8c8b947eba644cfd8c20446e1ba5d74055e6856b646dd6ad4bb470d9ae";
pub const SOLC_VERSION_0_6_1: semver::Version = semver::Version::new(0, 6, 1);
pub const SOLC_VERSION_0_6_1_CHECKSUM: &str =
    "f1649bfdb0e6e53be2758544836258cb4d02e0b381a9e43216aa2b2fad0c9b8e";
pub const SOLC_VERSION_0_6_2: semver::Version = semver::Version::new(0, 6, 2);
pub const SOLC_VERSION_0_6_2_CHECKSUM: &str =
    "2bb19d8cd69a32854acce1245b4492cfc5b5e751d322d2c6556d4a521bfcc3c8";
pub const SOLC_VERSION_0_6_3: semver::Version = semver::Version::new(0, 6, 3);
pub const SOLC_VERSION_0_6_3_CHECKSUM: &str =
    "a09350d5a182b3da799c203d1dadc4ce0e6fe3b96dc9ee1c9d73e9a9d9592e2a";
pub const SOLC_VERSION_0_6_4: semver::Version = semver::Version::new(0, 6, 4);
pub const SOLC_VERSION_0_6_4_CHECKSUM: &str =
    "082fd42cc96c28262459306f2854fe7049cc0d14473e126b2db6d30bf02f54d0";
pub const SOLC_VERSION_0_6_5: semver::Version = semver::Version::new(0, 6, 5);
pub const SOLC_VERSION_0_6_5_CHECKSUM: &str =
    "a8129254b5247bbe003d6e54f35c0bba853694126744577289b6bdf1d35a1e4a";
pub const SOLC_VERSION_0_6_6: semver::Version = semver::Version::new(0, 6, 6);
pub const SOLC_VERSION_0_6_6_CHECKSUM: &str =
    "45c7f956197ce08b69f793ea610cf1ee65e12b6a518d6160cc28c8eeff41517c";
pub const SOLC_VERSION_0_6_7: semver::Version = semver::Version::new(0, 6, 7);
pub const SOLC_VERSION_0_6_7_CHECKSUM: &str =
    "bb78b6de3df7db6115a1033346c3e9df8a6b9c4fd038cc12d6bdf16abd29c952";
pub const SOLC_VERSION_0_6_8: semver::Version = semver::Version::new(0, 6, 8);
pub const SOLC_VERSION_0_6_8_CHECKSUM: &str =
    "801efaa3d0288637021667c0d116ee2b339e62cf26027f8c168259e0805e8b60";
pub const SOLC_VERSION_0_6_9: semver::Version = semver::Version::new(0, 6, 9);
pub const SOLC_VERSION_0_6_9_CHECKSUM: &str =
    "98fbe10755638ad5ccc0683810b961a803450e94b642af112593248a685aa4dc";
pub const SOLC_VERSION_0_6_10: semver::Version = semver::Version::new(0, 6, 10);
pub const SOLC_VERSION_0_6_10_CHECKSUM: &str =
    "3773e66c3ef14e2e47bdd7d06f30f952c199856df240d164c91c1f00806fbbc7";
pub const SOLC_VERSION_0_6_11: semver::Version = semver::Version::new(0, 6, 11);
pub const SOLC_VERSION_0_6_11_CHECKSUM: &str =
    "a0a64aa092a616ae7145da908fc427fc3c296d3afdbfa8ea3468a22722d5d01c";
pub const SOLC_VERSION_0_6_12: semver::Version = semver::Version::new(0, 6, 12);
pub const SOLC_VERSION_0_6_12_CHECKSUM: &str =
    "05ad8afa83df3b51d36fe9a84ea4467b3ed17585c903946985d6e2cd5e95685a";
pub const SOLC_VERSION_0_7_0: semver::Version = semver::Version::new(0, 7, 0);
pub const SOLC_VERSION_0_7_0_CHECKSUM: &str =
    "40555d6e826104cacd0c0b637c5fb573d5b6e2a6ac70110dc0333466c0115e1d";
pub const SOLC_VERSION_0_7_1: semver::Version = semver::Version::new(0, 7, 1);
pub const SOLC_VERSION_0_7_1_CHECKSUM: &str =
    "55b8072cc6ac154bf27f22177afe58be05f28c11ef51fc4e660313d3045a4268";
pub const SOLC_VERSION_0_7_2: semver::Version = semver::Version::new(0, 7, 2);
pub const SOLC_VERSION_0_7_2_CHECKSUM: &str =
    "5518641f6c4a286054f5c9f29146970ef72f2f34ee76ed23f5eb1f6d1dcfecdb";
pub const SOLC_VERSION_0_7_3: semver::Version = semver::Version::new(0, 7, 3);
pub const SOLC_VERSION_0_7_3_CHECKSUM: &str =
    "f185104ed5e2a90b3ce8dfc7283c5d0ffbb738d7c8da19e8635dd9fda34c337a";
pub const SOLC_VERSION_0_7_4: semver::Version = semver::Version::new(0, 7, 4);
pub const SOLC_VERSION_0_7_4_CHECKSUM: &str =
    "cce002688cf10fb0243a042503f3e9896aa991ab59b08b57971d42d68e99f83d";
pub const SOLC_VERSION_0_7_5: semver::Version = semver::Version::new(0, 7, 5);
pub const SOLC_VERSION_0_7_5_CHECKSUM: &str =
    "1c100ce86a3167fd4c194290aafec0d3d94fe86c7a1aa0837c1346cc93d8b6ce";
pub const SOLC_VERSION_0_7_6: semver::Version = semver::Version::new(0, 7, 6);
pub const SOLC_VERSION_0_7_6_CHECKSUM: &str =
    "a6a8f9f9388c5fcd9222474e00270242c832e936b0f5257c20374d27ee5bd1ab";
pub const SOLC_VERSION_0_8_0: semver::Version = semver::Version::new(0, 8, 0);
pub const SOLC_VERSION_0_8_0_CHECKSUM: &str =
    "c7c3ff484d2dd69350fc182d44ecf6057ff2885b96a1c3990ca362e9c8325335";
pub const SOLC_VERSION_0_8_1: semver::Version = semver::Version::new(0, 8, 1);
pub const SOLC_VERSION_0_8_1_CHECKSUM: &str =
    "38504e357632c15afed612c20ef878992ca8411ce3fb6afee37dec6ebd22ce02";
pub const SOLC_VERSION_0_8_2: semver::Version = semver::Version::new(0, 8, 2);
pub const SOLC_VERSION_0_8_2_CHECKSUM: &str =
    "0898c23b0ac8cdabcee3b646b676da1205f4be7c0bec8a58de81b060c59b4c1c";
pub const SOLC_VERSION_0_8_3: semver::Version = semver::Version::new(0, 8, 3);
pub const SOLC_VERSION_0_8_3_CHECKSUM: &str =
    "1188f5c24d33ec1ec2ce811a7a45bdc3c167f1ba71cbc2664016564d2fdd46ba";
pub const SOLC_VERSION_0_8_4: semver::Version = semver::Version::new(0, 8, 4);
pub const SOLC_VERSION_0_8_4_CHECKSUM: &str =
    "4f6f2e6942a09051bbbc850d4fa9b0d907749612cb5db58cac0c87745435070f";
pub const SOLC_VERSION_0_8_5: semver::Version = semver::Version::new(0, 8, 5);
pub const SOLC_VERSION_0_8_5_CHECKSUM: &str =
    "3421ee67a26ef4a720e79531ffd9b96deec89defbcd70bb4a33e968b12ddb938";
pub const SOLC_VERSION_0_8_6: semver::Version = semver::Version::new(0, 8, 6);
pub const SOLC_VERSION_0_8_6_CHECKSUM: &str =
    "86ee99f64fc7e36bfa046169b6a4d4c10eb35017ed11e0c970f01223b2f5db36";
pub const SOLC_VERSION_0_8_7: semver::Version = semver::Version::new(0, 8, 7);
pub const SOLC_VERSION_0_8_7_CHECKSUM: &str =
    "cc5c663d1fe17d4eb4aca09253787ac86b8785235fca71d9200569e662677990";
pub const SOLC_VERSION_0_8_8: semver::Version = semver::Version::new(0, 8, 8);
pub const SOLC_VERSION_0_8_8_CHECKSUM: &str =
    "1422e10454251d56fef62940fb2e209a6f467ae35f73bdce580bc0bad35851dd";
pub const SOLC_VERSION_0_8_9: semver::Version = semver::Version::new(0, 8, 9);
pub const SOLC_VERSION_0_8_9_CHECKSUM: &str =
    "d619d4f5d8fd988bc63262407e749e905ccc8d8ab1ccf0280da1d12b918894ce";
pub const SOLC_VERSION_0_8_10: semver::Version = semver::Version::new(0, 8, 10);
pub const SOLC_VERSION_0_8_10_CHECKSUM: &str =
    "a79fff23aeb35be856e446827c44a9cfa4c382f29babd2f6a405ef73d1e2a4cc";
pub const SOLC_VERSION_0_8_11: semver::Version = semver::Version::new(0, 8, 11);
pub const SOLC_VERSION_0_8_11_CHECKSUM: &str =
    "10cdcc8d8ea4dde9fd8b953b95885dc737f24b8a31fea65f4715ffd007b80281";
pub const SOLC_VERSION_0_8_12: semver::Version = semver::Version::new(0, 8, 12);
pub const SOLC_VERSION_0_8_12_CHECKSUM: &str =
    "95738a27909a13502385e9fe8f8f3d8a873d2faf5d06ff617bc2fe3edb8c4bf9";
pub const SOLC_VERSION_0_8_13: semver::Version = semver::Version::new(0, 8, 13);
pub const SOLC_VERSION_0_8_13_CHECKSUM: &str =
    "14d4ef013ea82ad95e91fd949b7fa7b78271a483ff1a79c43d6cc58b826f5bea";
/// All available releases for macosx-amd64
pub static ALL_SOLC_VERSIONS: [semver::Version; 80] = [
    SOLC_VERSION_0_3_6,
    SOLC_VERSION_0_4_0,
    SOLC_VERSION_0_4_1,
    SOLC_VERSION_0_4_2,
    SOLC_VERSION_0_4_3,
    SOLC_VERSION_0_4_4,
    SOLC_VERSION_0_4_5,
    SOLC_VERSION_0_4_6,
    SOLC_VERSION_0_4_7,
    SOLC_VERSION_0_4_8,
    SOLC_VERSION_0_4_9,
    SOLC_VERSION_0_4_10,
    SOLC_VERSION_0_4_11,
    SOLC_VERSION_0_4_12,
    SOLC_VERSION_0_4_13,
    SOLC_VERSION_0_4_14,
    SOLC_VERSION_0_4_15,
    SOLC_VERSION_0_4_16,
    SOLC_VERSION_0_4_17,
    SOLC_VERSION_0_4_18,
    SOLC_VERSION_0_4_19,
    SOLC_VERSION_0_4_20,
    SOLC_VERSION_0_4_21,
    SOLC_VERSION_0_4_22,
    SOLC_VERSION_0_4_23,
    SOLC_VERSION_0_4_24,
    SOLC_VERSION_0_4_25,
    SOLC_VERSION_0_4_26,
    SOLC_VERSION_0_5_0,
    SOLC_VERSION_0_5_1,
    SOLC_VERSION_0_5_2,
    SOLC_VERSION_0_5_3,
    SOLC_VERSION_0_5_4,
    SOLC_VERSION_0_5_5,
    SOLC_VERSION_0_5_6,
    SOLC_VERSION_0_5_7,
    SOLC_VERSION_0_5_8,
    SOLC_VERSION_0_5_9,
    SOLC_VERSION_0_5_10,
    SOLC_VERSION_0_5_11,
    SOLC_VERSION_0_5_12,
    SOLC_VERSION_0_5_13,
    SOLC_VERSION_0_5_14,
    SOLC_VERSION_0_5_15,
    SOLC_VERSION_0_5_16,
    SOLC_VERSION_0_5_17,
    SOLC_VERSION_0_6_0,
    SOLC_VERSION_0_6_1,
    SOLC_VERSION_0_6_2,
    SOLC_VERSION_0_6_3,
    SOLC_VERSION_0_6_4,
    SOLC_VERSION_0_6_5,
    SOLC_VERSION_0_6_6,
    SOLC_VERSION_0_6_7,
    SOLC_VERSION_0_6_8,
    SOLC_VERSION_0_6_9,
    SOLC_VERSION_0_6_10,
    SOLC_VERSION_0_6_11,
    SOLC_VERSION_0_6_12,
    SOLC_VERSION_0_7_0,
    SOLC_VERSION_0_7_1,
    SOLC_VERSION_0_7_2,
    SOLC_VERSION_0_7_3,
    SOLC_VERSION_0_7_4,
    SOLC_VERSION_0_7_5,
    SOLC_VERSION_0_7_6,
    SOLC_VERSION_0_8_0,
    SOLC_VERSION_0_8_1,
    SOLC_VERSION_0_8_2,
    SOLC_VERSION_0_8_3,
    SOLC_VERSION_0_8_4,
    SOLC_VERSION_0_8_5,
    SOLC_VERSION_0_8_6,
    SOLC_VERSION_0_8_7,
    SOLC_VERSION_0_8_8,
    SOLC_VERSION_0_8_9,
    SOLC_VERSION_0_8_10,
    SOLC_VERSION_0_8_11,
    SOLC_VERSION_0_8_12,
    SOLC_VERSION_0_8_13,
];
/// Get the checksum of a solc version's binary if it exists.
pub fn get_checksum(version: &semver::Version) -> Option<Vec<u8>> {
    let checksum = match (version.major, version.minor, version.patch) {
        (0, 3, 6) => SOLC_VERSION_0_3_6_CHECKSUM,
        (0, 4, 0) => SOLC_VERSION_0_4_0_CHECKSUM,
        (0, 4, 1) => SOLC_VERSION_0_4_1_CHECKSUM,
        (0, 4, 2) => SOLC_VERSION_0_4_2_CHECKSUM,
        (0, 4, 3) => SOLC_VERSION_0_4_3_CHECKSUM,
        (0, 4, 4) => SOLC_VERSION_0_4_4_CHECKSUM,
        (0, 4, 5) => SOLC_VERSION_0_4_5_CHECKSUM,
        (0, 4, 6) => SOLC_VERSION_0_4_6_CHECKSUM,
        (0, 4, 7) => SOLC_VERSION_0_4_7_CHECKSUM,
        (0, 4, 8) => SOLC_VERSION_0_4_8_CHECKSUM,
        (0, 4, 9) => SOLC_VERSION_0_4_9_CHECKSUM,
        (0, 4, 10) => SOLC_VERSION_0_4_10_CHECKSUM,
        (0, 4, 11) => SOLC_VERSION_0_4_11_CHECKSUM,
        (0, 4, 12) => SOLC_VERSION_0_4_12_CHECKSUM,
        (0, 4, 13) => SOLC_VERSION_0_4_13_CHECKSUM,
        (0, 4, 14) => SOLC_VERSION_0_4_14_CHECKSUM,
        (0, 4, 15) => SOLC_VERSION_0_4_15_CHECKSUM,
        (0, 4, 16) => SOLC_VERSION_0_4_16_CHECKSUM,
        (0, 4, 17) => SOLC_VERSION_0_4_17_CHECKSUM,
        (0, 4, 18) => SOLC_VERSION_0_4_18_CHECKSUM,
        (0, 4, 19) => SOLC_VERSION_0_4_19_CHECKSUM,
        (0, 4, 20) => SOLC_VERSION_0_4_20_CHECKSUM,
        (0, 4, 21) => SOLC_VERSION_0_4_21_CHECKSUM,
        (0, 4, 22) => SOLC_VERSION_0_4_22_CHECKSUM,
        (0, 4, 23) => SOLC_VERSION_0_4_23_CHECKSUM,
        (0, 4, 24) => SOLC_VERSION_0_4_24_CHECKSUM,
        (0, 4, 25) => SOLC_VERSION_0_4_25_CHECKSUM,
        (0, 4, 26) => SOLC_VERSION_0_4_26_CHECKSUM,
        (0, 5, 0) => SOLC_VERSION_0_5_0_CHECKSUM,
        (0, 5, 1) => SOLC_VERSION_0_5_1_CHECKSUM,
        (0, 5, 2) => SOLC_VERSION_0_5_2_CHECKSUM,
        (0, 5, 3) => SOLC_VERSION_0_5_3_CHECKSUM,
        (0, 5, 4) => SOLC_VERSION_0_5_4_CHECKSUM,
        (0, 5, 5) => SOLC_VERSION_0_5_5_CHECKSUM,
        (0, 5, 6) => SOLC_VERSION_0_5_6_CHECKSUM,
        (0, 5, 7) => SOLC_VERSION_0_5_7_CHECKSUM,
        (0, 5, 8) => SOLC_VERSION_0_5_8_CHECKSUM,
        (0, 5, 9) => SOLC_VERSION_0_5_9_CHECKSUM,
        (0, 5, 10) => SOLC_VERSION_0_5_10_CHECKSUM,
        (0, 5, 11) => SOLC_VERSION_0_5_11_CHECKSUM,
        (0, 5, 12) => SOLC_VERSION_0_5_12_CHECKSUM,
        (0, 5, 13) => SOLC_VERSION_0_5_13_CHECKSUM,
        (0, 5, 14) => SOLC_VERSION_0_5_14_CHECKSUM,
        (0, 5, 15) => SOLC_VERSION_0_5_15_CHECKSUM,
        (0, 5, 16) => SOLC_VERSION_0_5_16_CHECKSUM,
        (0, 5, 17) => SOLC_VERSION_0_5_17_CHECKSUM,
        (0, 6, 0) => SOLC_VERSION_0_6_0_CHECKSUM,
        (0, 6, 1) => SOLC_VERSION_0_6_1_CHECKSUM,
        (0, 6, 2) => SOLC_VERSION_0_6_2_CHECKSUM,
        (0, 6, 3) => SOLC_VERSION_0_6_3_CHECKSUM,
        (0, 6, 4) => SOLC_VERSION_0_6_4_CHECKSUM,
        (0, 6, 5) => SOLC_VERSION_0_6_5_CHECKSUM,
        (0, 6, 6) => SOLC_VERSION_0_6_6_CHECKSUM,
        (0, 6, 7) => SOLC_VERSION_0_6_7_CHECKSUM,
        (0, 6, 8) => SOLC_VERSION_0_6_8_CHECKSUM,
        (0, 6, 9) => SOLC_VERSION_0_6_9_CHECKSUM,
        (0, 6, 10) => SOLC_VERSION_0_6_10_CHECKSUM,
        (0, 6, 11) => SOLC_VERSION_0_6_11_CHECKSUM,
        (0, 6, 12) => SOLC_VERSION_0_6_12_CHECKSUM,
        (0, 7, 0) => SOLC_VERSION_0_7_0_CHECKSUM,
        (0, 7, 1) => SOLC_VERSION_0_7_1_CHECKSUM,
        (0, 7, 2) => SOLC_VERSION_0_7_2_CHECKSUM,
        (0, 7, 3) => SOLC_VERSION_0_7_3_CHECKSUM,
        (0, 7, 4) => SOLC_VERSION_0_7_4_CHECKSUM,
        (0, 7, 5) => SOLC_VERSION_0_7_5_CHECKSUM,
        (0, 7, 6) => SOLC_VERSION_0_7_6_CHECKSUM,
        (0, 8, 0) => SOLC_VERSION_0_8_0_CHECKSUM,
        (0, 8, 1) => SOLC_VERSION_0_8_1_CHECKSUM,
        (0, 8, 2) => SOLC_VERSION_0_8_2_CHECKSUM,
        (0, 8, 3) => SOLC_VERSION_0_8_3_CHECKSUM,
        (0, 8, 4) => SOLC_VERSION_0_8_4_CHECKSUM,
        (0, 8, 5) => SOLC_VERSION_0_8_5_CHECKSUM,
        (0, 8, 6) => SOLC_VERSION_0_8_6_CHECKSUM,
        (0, 8, 7) => SOLC_VERSION_0_8_7_CHECKSUM,
        (0, 8, 8) => SOLC_VERSION_0_8_8_CHECKSUM,
        (0, 8, 9) => SOLC_VERSION_0_8_9_CHECKSUM,
        (0, 8, 10) => SOLC_VERSION_0_8_10_CHECKSUM,
        (0, 8, 11) => SOLC_VERSION_0_8_11_CHECKSUM,
        (0, 8, 12) => SOLC_VERSION_0_8_12_CHECKSUM,
        (0, 8, 13) => SOLC_VERSION_0_8_13_CHECKSUM,
        _ => return None,
    };
    Some(hex::decode(checksum).expect("valid hex;"))
}
/// JSON release list
pub static RELEASE_LIST_JSON: &str = r#"{"builds":[{"version":"0.3.6","sha256":"02d581b5b373d8160b9e75d690dd2ee898c3e0f6a39bbda54cd0698224c09df4"},{"version":"0.4.0","sha256":"bba6e2c33935259c478060501a7fb0ee1db4b0c56567356c9d01b6ec0491a558"},{"version":"0.4.1","sha256":"2de730163c80670b2f4c1ef78dc77ab13f757aad1ead044761821293275c382b"},{"version":"0.4.2","sha256":"9882bb966b82c0f4847735dba20b517118cf5408ed2a872485750f6ff26cf98b"},{"version":"0.4.3","sha256":"3ac02a93f4c7c20b9f17b6038af25b41acb8cfe178040be0f2246adc8bb8fe0a"},{"version":"0.4.4","sha256":"38ceeea801b5952d74bdb79ae5bc6bbb4c187ee5941e2701de388fdf95322f58"},{"version":"0.4.5","sha256":"003b09c2f255d2a40c2b2a1798192f92e6a3f1b35bda1a35ba66675919be1555"},{"version":"0.4.6","sha256":"aef1ebf2d2783a31742a612461f13e0ffc656c4a5ce25a0eeb747186ce03b276"},{"version":"0.4.7","sha256":"fc386d2547b6f764a0c1139487ed1d4a19e334c510a727614ff8ebeb1bd01a93"},{"version":"0.4.8","sha256":"ebb64b8b8dd465bd53a52fa7063569115df176c7561ac4feb47004513e1df74b"},{"version":"0.4.9","sha256":"a5b4227ed259c474426d8a2ef380606766aa8ba7f65487ab177139b3a51f0dee"},{"version":"0.4.10","sha256":"40f179e4d27201ab726669dd26d594cfe10bf4dd6117495ee49d26f0dda9ef42"},{"version":"0.4.11","sha256":"287eab0187dd4bdec50226f3173526bd8d247adeebdf64bc0b7448711abbea61"},{"version":"0.4.12","sha256":"65cc92c918d6334f533a7596f62916825fc722b2a7a235729ed87cfbec622bcd"},{"version":"0.4.13","sha256":"701eebf0e37d172cb829dc1e65c74a46b3b96737f3866758f9894696a639b6b7"},{"version":"0.4.14","sha256":"a4ef22d9d36e75151bdd64720e69eddf57500883dd623c57805edb5ccb644a89"},{"version":"0.4.15","sha256":"e449a4980db4ff18e7ffe704b40083cded96cccf33986bf6a6bb6fe925eb86c0"},{"version":"0.4.16","sha256":"a24512aee16652c4469979715bbdcaa6c4afabb94b717bb40980e4b2d25c4709"},{"version":"0.4.17","sha256":"458c3e2de2ffe609b79d9cdc4eb3080d6ed7662ef1bdd7c8a03fb18f1ca9a137"},{"version":"0.4.18","sha256":"dddc86683d12d0f016b5d5799ed84f6f2a79f667ebb932b9a8e6bfe9a48c3190"},{"version":"0.4.19","sha256":"ace5107a68fa75634e26848d6d208b808a76cc4f9262e53e8a3622bcefd4dcaf"},{"version":"0.4.20","sha256":"47425e338b9461d3e6498a0b0d5c2b9cc7cf998e4aa69126ea9f64c0a176e605"},{"version":"0.4.21","sha256":"e035cb9a81b5e3e11a7b99ead6f51a3ef7729794eebee470a964e2c08e30b857"},{"version":"0.4.22","sha256":"a9341add7a4f01c52dbb36bb4028104676c684b0b6003a2cd9dd84a2a9802b59"},{"version":"0.4.23","sha256":"502eddb177f9268d79b1e05e6acfb2f229471823bf6711eff411d2a23e8cc0b1"},{"version":"0.4.24","sha256":"7034c4048bc713d5c14cdd6681953c736e2adbdb9174f8bfbfb6a097109ffaaa"},{"version":"0.4.25","sha256":"9dd7686975200be71ce731f153823e7ea0d68106f3354ea16fecd5975f5c98b7"},{"version":"0.4.26","sha256":"bc956645b792dcbb8f820b8010a8d4ec1e188f7b40c6af951a436da4c13ae677"},{"version":"0.5.0","sha256":"9fa663fc427e8e9613815ad6b83783b4e4cb10439f16ca0dcb12fc002c45ab5a"},{"version":"0.5.1","sha256":"f2bad43386065684b4e15b86a175410f5d1e4d234b052cba44eb50f4c74b021f"},{"version":"0.5.2","sha256":"9e7ee54f0bc2978fa8738b9603d636715a069d84771778d6195577bb91ecb9c8"},{"version":"0.5.3","sha256":"03a6cfa2d74e57ea38eee83ce9a3ea37a6e50928d7f109e74b37cae31319af2b"},{"version":"0.5.4","sha256":"32a8affa996d05c55257317cc700b9e5b4377d94919b59055564eb0b5f941773"},{"version":"0.5.5","sha256":"7fc0600cc150020402c9539ec0ad584eb9271b2d0e0bff9e3b4d4ca672be3452"},{"version":"0.5.6","sha256":"428f9c0873d88740242f6fc16a3ae6f91b35f73ddf7676b5d5b39687d9d9b7dc"},{"version":"0.5.7","sha256":"a7d6b8e3cb22d90789a79b484b721fe02943f89e9b7e996863edd2d40ba7b524"},{"version":"0.5.8","sha256":"9f383896c8506cd96ac5ef9c97d7ab1c385fb5f4772a5f3d2cf8715cae793554"},{"version":"0.5.9","sha256":"92e3688207c0c2b86bd9d10088340e4a585e29e3a88d1cf79c2043f4f9f121c4"},{"version":"0.5.10","sha256":"5082bb5c492ca35b68b0c3e24d5934b56d3add83f1400ba95654e8f163c741ff"},{"version":"0.5.11","sha256":"0e8ee89ddb1096b81c34e11bdb5985822e749d3a9dc4e7218ba2474afa6400cb"},{"version":"0.5.12","sha256":"3dfb97bc941492afaea7f404c3fb9c6fe215b3386aa6e0370791b571e4679548"},{"version":"0.5.13","sha256":"68a344d9de40b0d7482089ee7748e43088c52e3b108480d801b34c64020beb48"},{"version":"0.5.14","sha256":"8afa926b6bb8ad492fb25078b1dce09fd05faa5765e4e2b2672b3c99cf71eeb1"},{"version":"0.5.15","sha256":"9e05051c3d42a49c8470cbed1f2bfa89fe76e930a9e5558c52ce5653cf794e25"},{"version":"0.5.16","sha256":"9f6624e408497142bbd29efe0744ee25e445aeb7c932be401c0bc30478a6bb75"},{"version":"0.5.17","sha256":"35be28f68488b71f1de66148f915b91d64e062900e4fc175bf2eb8fb948810bd"},{"version":"0.6.0","sha256":"37beed8c8b947eba644cfd8c20446e1ba5d74055e6856b646dd6ad4bb470d9ae"},{"version":"0.6.1","sha256":"f1649bfdb0e6e53be2758544836258cb4d02e0b381a9e43216aa2b2fad0c9b8e"},{"version":"0.6.2","sha256":"2bb19d8cd69a32854acce1245b4492cfc5b5e751d322d2c6556d4a521bfcc3c8"},{"version":"0.6.3","sha256":"a09350d5a182b3da799c203d1dadc4ce0e6fe3b96dc9ee1c9d73e9a9d9592e2a"},{"version":"0.6.4","sha256":"082fd42cc96c28262459306f2854fe7049cc0d14473e126b2db6d30bf02f54d0"},{"version":"0.6.5","sha256":"a8129254b5247bbe003d6e54f35c0bba853694126744577289b6bdf1d35a1e4a"},{"version":"0.6.6","sha256":"45c7f956197ce08b69f793ea610cf1ee65e12b6a518d6160cc28c8eeff41517c"},{"version":"0.6.7","sha256":"bb78b6de3df7db6115a1033346c3e9df8a6b9c4fd038cc12d6bdf16abd29c952"},{"version":"0.6.8","sha256":"801efaa3d0288637021667c0d116ee2b339e62cf26027f8c168259e0805e8b60"},{"version":"0.6.9","sha256":"98fbe10755638ad5ccc0683810b961a803450e94b642af112593248a685aa4dc"},{"version":"0.6.10","sha256":"3773e66c3ef14e2e47bdd7d06f30f952c199856df240d164c91c1f00806fbbc7"},{"version":"0.6.11","sha256":"a0a64aa092a616ae7145da908fc427fc3c296d3afdbfa8ea3468a22722d5d01c"},{"version":"0.6.12","sha256":"05ad8afa83df3b51d36fe9a84ea4467b3ed17585c903946985d6e2cd5e95685a"},{"version":"0.7.0","sha256":"40555d6e826104cacd0c0b637c5fb573d5b6e2a6ac70110dc0333466c0115e1d"},{"version":"0.7.1","sha256":"55b8072cc6ac154bf27f22177afe58be05f28c11ef51fc4e660313d3045a4268"},{"version":"0.7.2","sha256":"5518641f6c4a286054f5c9f29146970ef72f2f34ee76ed23f5eb1f6d1dcfecdb"},{"version":"0.7.3","sha256":"f185104ed5e2a90b3ce8dfc7283c5d0ffbb738d7c8da19e8635dd9fda34c337a"},{"version":"0.7.4","sha256":"cce002688cf10fb0243a042503f3e9896aa991ab59b08b57971d42d68e99f83d"},{"version":"0.7.5","sha256":"1c100ce86a3167fd4c194290aafec0d3d94fe86c7a1aa0837c1346cc93d8b6ce"},{"version":"0.7.6","sha256":"a6a8f9f9388c5fcd9222474e00270242c832e936b0f5257c20374d27ee5bd1ab"},{"version":"0.8.0","sha256":"c7c3ff484d2dd69350fc182d44ecf6057ff2885b96a1c3990ca362e9c8325335"},{"version":"0.8.1","sha256":"38504e357632c15afed612c20ef878992ca8411ce3fb6afee37dec6ebd22ce02"},{"version":"0.8.2","sha256":"0898c23b0ac8cdabcee3b646b676da1205f4be7c0bec8a58de81b060c59b4c1c"},{"version":"0.8.3","sha256":"1188f5c24d33ec1ec2ce811a7a45bdc3c167f1ba71cbc2664016564d2fdd46ba"},{"version":"0.8.4","sha256":"4f6f2e6942a09051bbbc850d4fa9b0d907749612cb5db58cac0c87745435070f"},{"version":"0.8.5","sha256":"3421ee67a26ef4a720e79531ffd9b96deec89defbcd70bb4a33e968b12ddb938"},{"version":"0.8.6","sha256":"86ee99f64fc7e36bfa046169b6a4d4c10eb35017ed11e0c970f01223b2f5db36"},{"version":"0.8.7","sha256":"cc5c663d1fe17d4eb4aca09253787ac86b8785235fca71d9200569e662677990"},{"version":"0.8.8","sha256":"1422e10454251d56fef62940fb2e209a6f467ae35f73bdce580bc0bad35851dd"},{"version":"0.8.9","sha256":"d619d4f5d8fd988bc63262407e749e905ccc8d8ab1ccf0280da1d12b918894ce"},{"version":"0.8.10","sha256":"a79fff23aeb35be856e446827c44a9cfa4c382f29babd2f6a405ef73d1e2a4cc"},{"version":"0.8.11","sha256":"10cdcc8d8ea4dde9fd8b953b95885dc737f24b8a31fea65f4715ffd007b80281"},{"version":"0.8.12","sha256":"95738a27909a13502385e9fe8f8f3d8a873d2faf5d06ff617bc2fe3edb8c4bf9"},{"version":"0.8.13","sha256":"14d4ef013ea82ad95e91fd949b7fa7b78271a483ff1a79c43d6cc58b826f5bea"}],"releases":{"0.3.6":"solc-macosx-amd64-v0.3.6+commit.988fe5e5","0.4.0":"solc-macosx-amd64-v0.4.0+commit.acd334c9","0.4.1":"solc-macosx-amd64-v0.4.1+commit.4fc6fc2c","0.4.2":"solc-macosx-amd64-v0.4.2+commit.af6afb04","0.4.3":"solc-macosx-amd64-v0.4.3+commit.2353da71","0.4.4":"solc-macosx-amd64-v0.4.4+commit.4633f3de","0.4.5":"solc-macosx-amd64-v0.4.5+commit.b318366e","0.4.6":"solc-macosx-amd64-v0.4.6+commit.2dabbdf0","0.4.7":"solc-macosx-amd64-v0.4.7+commit.822622cf","0.4.8":"solc-macosx-amd64-v0.4.8+commit.60cc1668","0.4.9":"solc-macosx-amd64-v0.4.9+commit.364da425","0.4.10":"solc-macosx-amd64-v0.4.10+commit.f0d539ae","0.4.11":"solc-macosx-amd64-v0.4.11+commit.68ef5810","0.4.12":"solc-macosx-amd64-v0.4.12+commit.194ff033","0.4.13":"solc-macosx-amd64-v0.4.13+commit.0fb4cb1a","0.4.14":"solc-macosx-amd64-v0.4.14+commit.c2215d46","0.4.15":"solc-macosx-amd64-v0.4.15+commit.8b45bddb","0.4.16":"solc-macosx-amd64-v0.4.16+commit.d7661dd9","0.4.17":"solc-macosx-amd64-v0.4.17+commit.bdeb9e52","0.4.18":"solc-macosx-amd64-v0.4.18+commit.9cf6e910","0.4.19":"solc-macosx-amd64-v0.4.19+commit.c4cbbb05","0.4.20":"solc-macosx-amd64-v0.4.20+commit.3155dd80","0.4.21":"solc-macosx-amd64-v0.4.21+commit.dfe3193c","0.4.22":"solc-macosx-amd64-v0.4.22+commit.4cb486ee","0.4.23":"solc-macosx-amd64-v0.4.23+commit.124ca40d","0.4.24":"solc-macosx-amd64-v0.4.24+commit.e67f0147","0.4.25":"solc-macosx-amd64-v0.4.25+commit.59dbf8f1","0.4.26":"solc-macosx-amd64-v0.4.26+commit.4563c3fc","0.5.0":"solc-macosx-amd64-v0.5.0+commit.1d4f565a","0.5.1":"solc-macosx-amd64-v0.5.1+commit.c8a2cb62","0.5.2":"solc-macosx-amd64-v0.5.2+commit.1df8f40c","0.5.3":"solc-macosx-amd64-v0.5.3+commit.10d17f24","0.5.4":"solc-macosx-amd64-v0.5.4+commit.9549d8ff","0.5.5":"solc-macosx-amd64-v0.5.5+commit.47a71e8f","0.5.6":"solc-macosx-amd64-v0.5.6+commit.b259423e","0.5.7":"solc-macosx-amd64-v0.5.7+commit.6da8b019","0.5.8":"solc-macosx-amd64-v0.5.8+commit.23d335f2","0.5.9":"solc-macosx-amd64-v0.5.9+commit.c68bc34e","0.5.10":"solc-macosx-amd64-v0.5.10+commit.5a6ea5b1","0.5.11":"solc-macosx-amd64-v0.5.11+commit.22be8592","0.5.12":"solc-macosx-amd64-v0.5.12+commit.7709ece9","0.5.13":"solc-macosx-amd64-v0.5.13+commit.5b0b510c","0.5.14":"solc-macosx-amd64-v0.5.14+commit.01f1aaa4","0.5.15":"solc-macosx-amd64-v0.5.15+commit.6a57276f","0.5.16":"solc-macosx-amd64-v0.5.16+commit.9c3226ce","0.5.17":"solc-macosx-amd64-v0.5.17+commit.d19bba13","0.6.0":"solc-macosx-amd64-v0.6.0+commit.26b70077","0.6.1":"solc-macosx-amd64-v0.6.1+commit.e6f7d5a4","0.6.2":"solc-macosx-amd64-v0.6.2+commit.bacdbe57","0.6.3":"solc-macosx-amd64-v0.6.3+commit.8dda9521","0.6.4":"solc-macosx-amd64-v0.6.4+commit.1dca32f3","0.6.5":"solc-macosx-amd64-v0.6.5+commit.f956cc89","0.6.6":"solc-macosx-amd64-v0.6.6+commit.6c089d02","0.6.7":"solc-macosx-amd64-v0.6.7+commit.b8d736ae","0.6.8":"solc-macosx-amd64-v0.6.8+commit.0bbfe453","0.6.9":"solc-macosx-amd64-v0.6.9+commit.3e3065ac","0.6.10":"solc-macosx-amd64-v0.6.10+commit.00c0fcaf","0.6.11":"solc-macosx-amd64-v0.6.11+commit.5ef660b1","0.6.12":"solc-macosx-amd64-v0.6.12+commit.27d51765","0.7.0":"solc-macosx-amd64-v0.7.0+commit.9e61f92b","0.7.1":"solc-macosx-amd64-v0.7.1+commit.f4a555be","0.7.2":"solc-macosx-amd64-v0.7.2+commit.51b20bc0","0.7.3":"solc-macosx-amd64-v0.7.3+commit.9bfce1f6","0.7.4":"solc-macosx-amd64-v0.7.4+commit.3f05b770","0.7.5":"solc-macosx-amd64-v0.7.5+commit.eb77ed08","0.7.6":"solc-macosx-amd64-v0.7.6+commit.7338295f","0.8.0":"solc-macosx-amd64-v0.8.0+commit.c7dfd78e","0.8.1":"solc-macosx-amd64-v0.8.1+commit.df193b15","0.8.2":"solc-macosx-amd64-v0.8.2+commit.661d1103","0.8.3":"solc-macosx-amd64-v0.8.3+commit.8d00100c","0.8.4":"solc-macosx-amd64-v0.8.4+commit.c7e474f2","0.8.5":"solc-macosx-amd64-v0.8.5+commit.a4f2e591","0.8.6":"solc-macosx-amd64-v0.8.6+commit.11564f7e","0.8.7":"solc-macosx-amd64-v0.8.7+commit.e28d00a7","0.8.8":"solc-macosx-amd64-v0.8.8+commit.dddeac2f","0.8.9":"solc-macosx-amd64-v0.8.9+commit.e5eed63a","0.8.10":"solc-macosx-amd64-v0.8.10+commit.fc410830","0.8.11":"solc-macosx-amd64-v0.8.11+commit.d7f03943","0.8.12":"solc-macosx-amd64-v0.8.12+commit.f00d7308","0.8.13":"solc-macosx-amd64-v0.8.13+commit.abaa5c0e"}}"#;

```
