### PR TITLE
feat: use fs2 for locking and increase request timeout to 60 secs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,6 +1124,7 @@ dependencies = [
  "clap",
  "console 0.14.1",
  "dialoguer",
+ "fs2",
  "hex",
  "home",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ cfg-if = { version = "1.0.0", default-features = false }
 clap = { version = "3.0.6", features = ["derive"] }
 console = { version = "0.14.1", default-features = false }
 dialoguer = { version = "0.8.0", default-features = false }
+fs2 = "0.4.3"
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 home = { version = "0.5.3", default-features = false }
 indicatif = { version = "0.16.2", default-features = false }


### PR DESCRIPTION
* this replaces the old locking code with [`fs2::FileExt`](https://docs.rs/fs2/latest/fs2/trait.FileExt.html)

* also bumps timeout to 60 secs, default is 30 and can be exceeded easily on slow networks