### PR TITLE
chore: bump up request timeout for fetching solc binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Linting
       run: cargo clippy -- -D warnings
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --all-features
 
   windows-build:
     runs-on: windows-latest

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ pub static SVM_HOME: Lazy<PathBuf> = Lazy::new(|| {
 });
 
 /// The timeout to use for requests to the source
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
 
 // Installer type that copies binary data to the appropriate solc binary file:
 // 1. create target file to copy binary data


### PR DESCRIPTION
Bumps up the `REQUEST_TIMEOUT` for fetching `solc` binary. Requested in https://github.com/gakonst/foundry/issues/1223