### PR TITLE
automatically patch binaries for nixos

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,8 @@ pub enum SolcVmError {
     ChecksumMismatch(String),
     #[error("Install step for solc version {0} timed out after {1} seconds")]
     Timeout(String, u64),
+    #[error("Unable to patch solc binary for nixos. stdout: {0}. stderr: {1}")]
+    CouldNotPatchForNixOs(String, String),
     #[error(transparent)]
     IoError(#[from] std::io::Error),
     #[error(transparent)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ impl Installer {
         let mut content = Cursor::new(&self.binbytes);
         std::io::copy(&mut content, &mut f)?;
 
-        if platform::is_nixos() {
+        if platform::is_nixos() && self.version.major == 0 && self.version.minor >= 8 {
             patch_for_nixos(solc_path)
         } else {
             Ok(solc_path)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use once_cell::sync::Lazy;
-use semver::Version;
+use semver::{Version, VersionReq};
 use sha2::Digest;
 
 use std::{
@@ -44,6 +44,9 @@ pub static SVM_HOME: Lazy<PathBuf> = Lazy::new(|| {
 /// The timeout to use for requests to the source
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 
+/// Version beyond which solc binaries are not fully static, hence need to be patched for NixOS.
+static NIXOS_PATCH_REQ: Lazy<VersionReq> = Lazy::new(|| VersionReq::parse(">=0.8.0").unwrap());
+
 // Installer type that copies binary data to the appropriate solc binary file:
 // 1. create target file to copy binary data
 // 2. copy data
@@ -69,7 +72,7 @@ impl Installer {
         let mut content = Cursor::new(&self.binbytes);
         std::io::copy(&mut content, &mut f)?;
 
-        if platform::is_nixos() && self.version.major == 0 && self.version.minor >= 8 {
+        if platform::is_nixos() && NIXOS_PATCH_REQ.matches(&self.version) {
             patch_for_nixos(solc_path)
         } else {
             Ok(solc_path)

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -42,6 +42,10 @@ impl FromStr for Platform {
     }
 }
 
+pub fn is_nixos() -> bool {
+    std::path::Path::new("/etc/NIXOS").exists()
+}
+
 /// Read the current machine's platform.
 pub fn platform() -> Platform {
     match (env::consts::OS, env::consts::ARCH) {


### PR DESCRIPTION
Implements https://github.com/roynalnaruto/svm-rs/issues/36.

This works by using `patchelf` to modify the dynamic linker in the installed solc binaries to use the nixos provided one (instead of the standard `/lib64/ld-linux-x86-64.so.2` which is not present on nixos).

Currently I've only tested locally with a few versions, and afaict it's working OK. I'm not sure what the automated testing strategy here is, but I would be more than happy to add some nixos specific tests / CI steps if you want.

Some more work will be needed to point the binaries to a nix provided version of z3/cvc (needed for the SMTChecker to work), but I'm going to leave that for another PR. 