### PR TITLE
feat: add offline feature

### DIFF
--- a/svm-builds/Cargo.toml
+++ b/svm-builds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "svm-rs-builds"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["Matthias Seitz <matthias.seitz@outlook.de>", "Rohit Narurkar <rohit.narurkar@protonmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/svm-builds/Cargo.toml
+++ b/svm-builds/Cargo.toml
@@ -23,3 +23,11 @@ serde_json = "1.0.79"
 build_const = "0.2.2"
 hex = "0.4.3"
 semver = { version = "1.0.4", default-features = false, features = ["std", "serde"] }
+
+[features]
+# helper feature to block network access
+_offline = []
+
+[package.metadata.docs.rs]
+# network access is blocked during builds
+features = ["_offline"]

--- a/svm-builds/build.rs
+++ b/svm-builds/build.rs
@@ -105,7 +105,7 @@ pub const TARGET_PLATFORM: &str = "{}";
     ));
 }
 
-fn main() {
+fn generate() {
     let platform = get_platform();
     let releases = svm::blocking_all_releases(platform).expect("Failed to fetch releases");
 
@@ -129,4 +129,28 @@ pub static RELEASE_LIST_JSON : &str = {}"{}"{};"#,
     ));
 
     writer.finish();
+}
+
+/// generates an empty `RELEASE_LIST_JSON` static
+#[cfg(feature = "_offline")]
+fn generate_offline() {
+    let mut writer = build_const::ConstWriter::for_build("builds")
+        .unwrap()
+        .finish_dependencies();
+
+    let release_json = serde_json::to_string(&Releases::default()).unwrap();
+    writer.add_raw(&format!(
+        r#"
+/// JSON release list
+pub static RELEASE_LIST_JSON : &str = {}"{}"{};"#,
+        "r#", release_json, "#"
+    ));
+}
+
+fn main() {
+    #[cfg(not(feature = "_offline"))]
+    generate();
+
+    #[cfg(feature = "_offline")]
+    generate_offline();
 }


### PR DESCRIPTION
network access is blocked during docrs builds: https://docs.rs/about/builds

* add offline feature that generates empty constants