### PR TITLE
chore: check for DOCS_RS flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,7 +1361,7 @@ dependencies = [
 
 [[package]]
 name = "svm-rs-builds"
-version = "0.1.3"
+version = "0.1.5"
 dependencies = [
  "build_const",
  "hex",

--- a/svm-builds/Cargo.toml
+++ b/svm-builds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "svm-rs-builds"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["Matthias Seitz <matthias.seitz@outlook.de>", "Rohit Narurkar <rohit.narurkar@protonmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/svm-builds/build.rs
+++ b/svm-builds/build.rs
@@ -149,7 +149,12 @@ pub static RELEASE_LIST_JSON : &str = {}"{}"{};"#,
 
 fn main() {
     #[cfg(not(feature = "_offline"))]
-    generate();
+    if std::env::var("DOCS_RS").is_ok() {
+        // no network access allowed during docs rs builds
+        generate_offline();
+    } else {
+        generate();
+    }
 
     #[cfg(feature = "_offline")]
     generate_offline();


### PR DESCRIPTION
`[package.metadata.docs.rs]` settings are only respected for the crate that's being published so current behaviour will cause docs rs build failures in downstream deps

it's recommended to check for DOCS_RS env var: https://docs.rs/about/builds#detecting-docsrs

so if not offline mode also check for DOCS_RS env var

