### PR TITLE
fix: remove cfg for defining function

### DIFF
--- a/svm-builds/build.rs
+++ b/svm-builds/build.rs
@@ -132,7 +132,6 @@ pub static RELEASE_LIST_JSON : &str = {}"{}"{};"#,
 }
 
 /// generates an empty `RELEASE_LIST_JSON` static
-#[cfg(feature = "_offline")]
 fn generate_offline() {
     let mut writer = build_const::ConstWriter::for_build("builds")
         .unwrap()


### PR DESCRIPTION
Noticed this issue while publishing `svm-builds`: https://github.com/roynalnaruto/svm-rs/blob/master/svm-builds/build.rs#L151-L154

`generate_offline` is not compiled when `_offline` feature is not enabled. But the above snippet tries to use it.

I'm simply removing the `#[cfg(feature = "_offline")]` feature gate, so that `generate_offline` can be used in all cases where it's required.

@mattsse please have a look :)

