### PR TITLE
chore: switch `binstall-zip` to `zip`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,26 +56,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
 
 [[package]]
-name = "binstall-zip"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5eddcdebe8fe727d81b47734b3302ffa49a6fe50376fe6c52c609198c0709e5"
-dependencies = [
- "aes",
- "byteorder",
- "bzip2",
- "constant_time_eq",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
- "hmac",
- "pbkdf2",
- "sha1",
- "time",
- "zstd",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,7 +1335,6 @@ name = "svm-rs"
 version = "0.2.18"
 dependencies = [
  "anyhow",
- "binstall-zip",
  "cfg-if",
  "clap",
  "console 0.14.1",
@@ -1377,6 +1356,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "zip",
 ]
 
 [[package]]
@@ -1831,6 +1811,26 @@ name = "zeroize"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
+
+[[package]]
+name = "zip"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537ce7411d25e54e8ae21a7ce0b15840e7bfcff15b51d697ec3266cc76bdf080"
+dependencies = [
+ "aes",
+ "byteorder",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time",
+ "zstd",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ tracing = "0.1.30"
 url = { version = "2.2.2", default-features = false }
 
 [target.'cfg(all(target_os = "windows", target_arch = "x86_64"))'.dependencies]
-zip = { package = "binstall-zip", version = "0.6.3" }
+zip = "0.6.3"
 
 [build-dependencies]
 home = { version = "0.5.3", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ pub fn patch_for_nixos(bin: PathBuf) -> Result<PathBuf, SolcVmError> {
 /// Derive path to a specific Solc version's binary.
 pub fn version_path(version: &str) -> PathBuf {
     let mut version_path = SVM_HOME.to_path_buf();
-    version_path.push(&version);
+    version_path.push(version);
     version_path
 }
 


### PR DESCRIPTION
Follow up from #65 :

The original `zip` crate cut a new release and the `binstall-zip` fork is now deprecated.