### PR TITLE
nixos: patch solc 0.7.6, first dynamically-linked version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ pub static SVM_HOME: Lazy<PathBuf> = Lazy::new(|| {
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Version beyond which solc binaries are not fully static, hence need to be patched for NixOS.
-static NIXOS_PATCH_REQ: Lazy<VersionReq> = Lazy::new(|| VersionReq::parse(">=0.8.0").unwrap());
+static NIXOS_PATCH_REQ: Lazy<VersionReq> = Lazy::new(|| VersionReq::parse(">=0.7.6").unwrap());
 
 // Installer type that copies binary data to the appropriate solc binary file:
 // 1. create target file to copy binary data


### PR DESCRIPTION
From https://github.com/roynalnaruto/svm-rs/pull/48#discussion_r1109165184

solc 0.7.6 was the first version to be dynamically-linked against ld loader, and therefore doesn't work on NixOS.